### PR TITLE
Add Hint Tracking

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -343,6 +343,8 @@ namespace Archipelago.HollowKnight
             {
                 LogError($"Error invoking OnArchipelagoGameStarted:\n {ex}");
             }
+
+            HintTracker.Start(session);
         }
 
         private void Events_OnSceneChange(UnityEngine.SceneManagement.Scene obj)

--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -344,7 +344,7 @@ namespace Archipelago.HollowKnight
                 LogError($"Error invoking OnArchipelagoGameStarted:\n {ex}");
             }
 
-            HintTracker.Start(session);
+            ItemChangerMod.Modules.Add<HintTracker>();
         }
 
         private void Events_OnSceneChange(UnityEngine.SceneManagement.Scene obj)

--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -644,14 +644,19 @@ namespace Archipelago.HollowKnight
             {
                 foreach (AbstractItem item in pmt.Items)
                 {
-                    if (item.GetTag<ArchipelagoItemTag>(out tag)
-                        && !tag.Hinted
-                        && (tag.Flags.HasFlag(ItemFlags.Advancement) || tag.Flags.HasFlag(ItemFlags.NeverExclude))
-                        && !item.WasEverObtained()
-                        && !item.HasTag<DisableItemPreviewTag>())
+                    if (item.GetTag<ArchipelagoItemTag>(out tag) && !tag.Hinted)
                     {
-                        hintedTags.Add(tag);
-                        hintedLocationIDs.Add(tag.Location);
+                        if ((tag.Flags.HasFlag(ItemFlags.Advancement) || tag.Flags.HasFlag(ItemFlags.NeverExclude))
+                            && !item.WasEverObtained()
+                            && !item.HasTag<DisableItemPreviewTag>())
+                        {
+                            hintedTags.Add(tag);
+                            hintedLocationIDs.Add(tag.Location);
+                        }
+                        else
+                        {
+                            tag.Hinted = true;
+                        }
                     }
                 }
             }

--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -343,8 +343,6 @@ namespace Archipelago.HollowKnight
             {
                 LogError($"Error invoking OnArchipelagoGameStarted:\n {ex}");
             }
-
-            ItemChangerMod.Modules.Add<HintTracker>();
         }
 
         private void Events_OnSceneChange(UnityEngine.SceneManagement.Scene obj)

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -163,6 +163,8 @@ namespace Archipelago.HollowKnight
             {
                 ItemChangerMod.Modules.Add<ItemChanger.Modules.SplitSuperdash>();
             }
+            
+            ItemChangerMod.Modules.Add<HintTracker>();
         }
 
         private void RandomizeCharmCosts()

--- a/Archipelago.HollowKnight/Extensions.cs
+++ b/Archipelago.HollowKnight/Extensions.cs
@@ -9,7 +9,7 @@ public static class Extensions
         string text = item.GetPreviewName();
         if (item.GetTag(out CostTag tag))
         {
-            text += " - " + tag.Cost.GetCostText();
+            text += "  -  " + tag.Cost.GetCostText();
         }
         return text;
     }

--- a/Archipelago.HollowKnight/Extensions.cs
+++ b/Archipelago.HollowKnight/Extensions.cs
@@ -1,0 +1,16 @@
+﻿using ItemChanger;
+
+namespace Archipelago.HollowKnight;
+
+public static class Extensions
+{
+    public static string GetPreviewWithCost(this AbstractItem item)
+    {
+        string text = item.GetPreviewName();
+        if (item.GetTag(out CostTag tag))
+        {
+            text += " - " + tag.Cost.GetCostText();
+        }
+        return text;
+    }
+}

--- a/Archipelago.HollowKnight/HintTracker.cs
+++ b/Archipelago.HollowKnight/HintTracker.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Archipelago.HollowKnight.IC;
+using Archipelago.MultiClient.Net;
+using Archipelago.MultiClient.Net.Models;
+using ItemChanger;
+using ItemChanger.Internal;
+
+namespace Archipelago.HollowKnight;
+
+public static class HintTracker
+{
+
+    public static event Action OnArchipelagoHintUpdate;
+    
+    /// <summary>
+    ///  List of MultiClient.Net Hint's
+    /// </summary>
+    public static List<Hint> Hints;
+
+    private static ArchipelagoSession _session;
+
+    private static void UpdateHints(Hint[] arrayHints)
+    {
+        Hints = arrayHints.ToList();
+        foreach (var hint in Hints)
+        {
+            if (hint.FindingPlayer != Archipelago.Instance.session.ConnectionInfo.Slot)
+                continue;
+
+            var locationName = StripShopSuffix(_session.Locations.GetLocationNameFromId(hint.LocationId));
+            var location = Finder.GetLocation(locationName);
+            if (location == null)
+                continue;
+            if (!Ref.Settings.Placements.ContainsKey(locationName))
+                continue;
+
+            var placement = Ref.Settings.Placements[locationName];
+
+            if (placement == null)
+                continue;
+            
+            //get all items in the placement and set the hinted attribute in ArchipelagoItemTag to true.
+            foreach (var tag in placement.Items.Select(item => item.GetTag<ArchipelagoItemTag>()).Where(tag => tag.Location == hint.LocationId))
+            {
+                tag.Hinted = true;
+            }
+            
+            //if there is only 1 item in this placement mark the whole placement as visited.
+            if (placement.Items.Count > 1) continue;
+            placement.GetTag<ArchipelagoPlacementTag>().Hinted = true;
+            placement.AddVisitFlag(VisitState.Previewed);
+        }
+        
+        try
+        {
+            OnArchipelagoHintUpdate?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Archipelago.Instance.LogError($"Error invoking OnArchipelagoHintUpdate:\n {ex}");
+        }
+    }
+    
+    private static string StripShopSuffix(string location)
+    {
+        if (string.IsNullOrEmpty(location))
+        {
+            return null;
+        }
+
+        var names = new[]
+        {
+            LocationNames.Sly_Key, LocationNames.Sly, LocationNames.Iselda, LocationNames.Salubra,
+            LocationNames.Leg_Eater, LocationNames.Egg_Shop, LocationNames.Seer, LocationNames.Grubfather
+        };
+
+        foreach (var name in names)
+        {
+            if (location.StartsWith(name))
+            {
+                return location.Substring(0, name.Length);
+            }
+        }
+
+        return location;
+    }
+
+    public static void Start(ArchipelagoSession archipelagoSession)
+    {
+        _session = archipelagoSession;
+        _session.DataStorage.TrackHints(UpdateHints);
+    }
+}

--- a/Archipelago.HollowKnight/HintTracker.cs
+++ b/Archipelago.HollowKnight/HintTracker.cs
@@ -6,6 +6,8 @@ using Archipelago.MultiClient.Net;
 using Archipelago.MultiClient.Net.Models;
 using ItemChanger;
 using ItemChanger.Internal;
+using ItemChanger.Placements;
+using Steamworks;
 
 namespace Archipelago.HollowKnight;
 
@@ -24,33 +26,60 @@ public static class HintTracker
     private static void UpdateHints(Hint[] arrayHints)
     {
         Hints = arrayHints.ToList();
-        foreach (var hint in Hints)
+        foreach (Hint hint in Hints)
         {
             if (hint.FindingPlayer != Archipelago.Instance.session.ConnectionInfo.Slot)
                 continue;
 
-            var locationName = StripShopSuffix(_session.Locations.GetLocationNameFromId(hint.LocationId));
-            var location = Finder.GetLocation(locationName);
-            if (location == null)
-                continue;
-            if (!Ref.Settings.Placements.ContainsKey(locationName))
-                continue;
-
-            var placement = Ref.Settings.Placements[locationName];
+            if (!Archipelago.Instance.placementsByLocationID.ContainsKey(hint.LocationId)) continue;
+            AbstractPlacement placement = Archipelago.Instance.placementsByLocationID[hint.LocationId];
 
             if (placement == null)
                 continue;
             
-            //get all items in the placement and set the hinted attribute in ArchipelagoItemTag to true.
-            foreach (var tag in placement.Items.Select(item => item.GetTag<ArchipelagoItemTag>()).Where(tag => tag.Location == hint.LocationId))
+            // set the hinted tag for the single item in the placement that was hinted for.
+            foreach (ArchipelagoItemTag tag in placement.Items.Select(item => item.GetTag<ArchipelagoItemTag>()).Where(tag => tag.Location == hint.LocationId))
             {
                 tag.Hinted = true;
             }
             
-            //if there is only 1 item in this placement mark the whole placement as visited.
-            if (placement.Items.Count > 1) continue;
-            placement.GetTag<ArchipelagoPlacementTag>().Hinted = true;
-            placement.AddVisitFlag(VisitState.Previewed);
+            // if all items inside a placement have been hinted for then mark the entire placement as hinted.
+            if (placement.Items.TrueForAll(item => item.GetTag<ArchipelagoItemTag>().Hinted))
+            {
+                placement.GetTag<ArchipelagoPlacementTag>().Hinted = true;
+            }
+
+            if (placement is ShopPlacement)
+            {
+                List<(string, AbstractItem)> previewText = new();
+                ShopPlacement shop = (ShopPlacement) placement;
+                foreach (AbstractItem item in shop.Items)
+                {
+                    if (item.GetTag<ArchipelagoItemTag>().Hinted)
+                    {
+                        previewText.Add((item.GetPreviewWithCost(), item));
+                    }
+                    else
+                    {
+                        previewText.Add((Language.Language.Get("???", "IC"), item));
+                    }
+                    
+                }
+                shop.OnPreviewBatch(previewText);
+            }
+            else
+            {
+                List<string> previewText = new();
+                foreach (AbstractItem item in placement.Items)
+                {
+                    previewText.Add(item.GetTag<ArchipelagoItemTag>().Hinted
+                        ? item.GetPreviewWithCost()
+                        : Language.Language.Get("???", "IC"));
+                }
+                
+                placement.OnPreview(string.Join(", ", previewText));
+            }
+            
         }
         
         try
@@ -61,30 +90,6 @@ public static class HintTracker
         {
             Archipelago.Instance.LogError($"Error invoking OnArchipelagoHintUpdate:\n {ex}");
         }
-    }
-    
-    private static string StripShopSuffix(string location)
-    {
-        if (string.IsNullOrEmpty(location))
-        {
-            return null;
-        }
-
-        var names = new[]
-        {
-            LocationNames.Sly_Key, LocationNames.Sly, LocationNames.Iselda, LocationNames.Salubra,
-            LocationNames.Leg_Eater, LocationNames.Egg_Shop, LocationNames.Seer, LocationNames.Grubfather
-        };
-
-        foreach (var name in names)
-        {
-            if (location.StartsWith(name))
-            {
-                return location.Substring(0, name.Length);
-            }
-        }
-
-        return location;
     }
 
     public static void Start(ArchipelagoSession archipelagoSession)


### PR DESCRIPTION
subscribes to AP's hint notifications, and auto-marks all items and single-location placements as previewed. As well as adding an event that is fired when a hint update arrives from AP.

starts working on #162. 
I'm open for ideas on how we want to handle this, but for now this gives me enough to work with on the APMapMod.