### PR TITLE
allow access to RemotePlacements

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -504,7 +504,7 @@ namespace Archipelago.HollowKnight
                 sender = session.Players.GetPlayerName(netItem.Player);
             }
 
-            ArchipelagoPlacement pmt = new(sender);
+            RemotePlacement pmt = new(sender);
             InteropTag recentItemsTag = pmt.AddTag<InteropTag>();
             recentItemsTag.Message = "RecentItems";
             recentItemsTag.Properties["DisplaySource"] = sender;

--- a/Archipelago.HollowKnight/IC/RemotePlacement.cs
+++ b/Archipelago.HollowKnight/IC/RemotePlacement.cs
@@ -2,9 +2,9 @@
 
 namespace Archipelago.HollowKnight.IC
 {
-    internal class ArchipelagoPlacement : AbstractPlacement
+    public class RemotePlacement : AbstractPlacement
     {
-        public ArchipelagoPlacement(string Name) : base(Name)
+        public RemotePlacement(string Name) : base(Name)
         {
         }
 


### PR DESCRIPTION
renames ArchipelagoPlacement to RemotePlacement and makes it public so other mods can test for this specific placement type.