### PR TITLE
Start receiving items much later after loading a save

### DIFF
--- a/Archipelago.HollowKnight/IC/ArchipelagoTags.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoTags.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using Archipelago.MultiClient.Net.Enums;
+﻿using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Models;
 using ItemChanger;
 using ItemChanger.Tags;
+using System.Collections.Generic;
 
 namespace Archipelago.HollowKnight.IC
 {
@@ -82,11 +82,10 @@ namespace Archipelago.HollowKnight.IC
                         return;
                     }
                 }
-                {
-                    InteropTag tag = obj.Item.AddTag<InteropTag>();
-                    tag.Message = "RecentItems";
-                    tag.Properties["IgnoreItem"] = true;
-                }
+
+                InteropTag newTag = obj.Item.AddTag<InteropTag>();
+                newTag.Message = "RecentItems";
+                newTag.Properties["IgnoreItem"] = true;
             }
         }
 

--- a/Archipelago.HollowKnight/IC/RemotePlacement.cs
+++ b/Archipelago.HollowKnight/IC/RemotePlacement.cs
@@ -1,11 +1,28 @@
 ﻿using ItemChanger;
+using ItemChanger.Extensions;
+using ItemChanger.Internal;
+using ItemChanger.Tags;
 
 namespace Archipelago.HollowKnight.IC
 {
     public class RemotePlacement : AbstractPlacement
     {
-        public RemotePlacement(string Name) : base(Name)
+        private const string SINGLETON_NAME = "Remote_Items";
+
+        public RemotePlacement() : base(SINGLETON_NAME)
         {
+        }
+
+        public static RemotePlacement GetOrAddSingleton()
+        {
+            if (!Ref.Settings.Placements.TryGetValue(SINGLETON_NAME, out AbstractPlacement pmt))
+            {
+                pmt = new RemotePlacement();
+                CompletionWeightTag remoteCompletionWeightTag = pmt.AddTag<CompletionWeightTag>();
+                remoteCompletionWeightTag.Weight = 0;
+                ItemChangerMod.AddPlacements(pmt.Yield());
+            }
+            return (RemotePlacement) pmt;
         }
 
         protected override void OnLoad()


### PR DESCRIPTION
- Starts receiving items only after the first scene. This fixes several cosmetic issues:
    - Resolves #65
    - Starting inventory no longer displays twice in recent items display (no associated issue apparently)
- Persists the placement which is used to give remote items. Resolves #173