### PR TITLE
Add DeathLink Override

### DIFF
--- a/Archipelago.HollowKnight/ArchipelagoMod.cs
+++ b/Archipelago.HollowKnight/ArchipelagoMod.cs
@@ -267,6 +267,13 @@ namespace Archipelago.HollowKnight
                     "Enable or disable interaction with the Archipelago gifting system. Requires reloading the save to take effect.",
                     (v) => GS.EnableGifting = v == 1,
                     () => GS.EnableGifting ? 1 : 0
+                ),
+                new IMenuMod.MenuEntry(
+                    "DeathLink Override", 
+                    ["Use Yaml", "Override On", "Override Off"],
+                    "Override deathlink as set in the yaml file. Requires reloading the save to take effect.",
+                    (v) => GS.DeathLinkOverride = (DeathLinkOverride)Enum.Parse(typeof(DeathLinkOverride), v.Remove(' ')),
+                    () => GS.EnableGifting ? 1 : 0
                 )
             ];
         }

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -222,7 +222,8 @@ namespace Archipelago.HollowKnight
             ItemChangerMod.Modules.Add<RepositionShadeModule>();
             ItemChangerMod.Modules.Add<BenchSyncModule>();
 
-            if (SlotData.Options.DeathLink)
+            if ((SlotData.Options.DeathLink && Instance.GS.DeathLinkOverride == DeathLinkOverride.UseYaml)
+                || Instance.GS.DeathLinkOverride == DeathLinkOverride.OverrideOn)
             {
                 ItemChangerMod.Modules.Add<DeathLinkModule>();
             }

--- a/Archipelago.HollowKnight/Enums.cs
+++ b/Archipelago.HollowKnight/Enums.cs
@@ -13,6 +13,13 @@
         Shadeless = 1,
         Shade = 2
     }
+    
+    public enum DeathLinkOverride
+    {
+        UseYaml = 0,
+        OverrideOn = 1,
+        OverrideOff = 2
+    }
 
     public enum WhitePalaceOption
     {

--- a/Archipelago.HollowKnight/Settings.cs
+++ b/Archipelago.HollowKnight/Settings.cs
@@ -12,6 +12,7 @@
     {
         public ConnectionDetails MenuConnectionDetails { get; set; } = new();
         public bool EnableGifting { get; set; } = true;
+        public DeathLinkOverride DeathLinkOverride = DeathLinkOverride.UseYaml;
     }
 
     public record APLocalSettings


### PR DESCRIPTION
***I do not own Hollow Knight so these changes were made without the ability to build or test.***

Adds an option to the Archipelago options menu to override the deathlink option set in the yaml.
The option is added with the assumption that the value passed to the callback is a string and the enum value is parsed from string after removing spaces.

```cs
new IMenuMod.MenuEntry(
    "DeathLink Override", 
    ["Use Yaml", "Override On", "Override Off"],
    "Override deathlink as set in the yaml file. Requires reloading the save to take effect.",
    (v) => GS.DeathLinkOverride = (DeathLinkOverride)Enum.Parse(typeof(DeathLinkOverride), v.Remove(' ')),
    () => GS.EnableGifting ? 1 : 0
)
```

The option is added as an enum type to the global save data
```cs
public record APGlobalSettings
{
    public ConnectionDetails MenuConnectionDetails { get; set; } = new();
    public bool EnableGifting { get; set; } = true;
    public DeathLinkOverride DeathLinkOverride = DeathLinkOverride.UseYaml;
}
```

Then used to determine if the module should be added.
```cs
if ((SlotData.Options.DeathLink && Instance.GS.DeathLinkOverride == DeathLinkOverride.UseYaml)
     || Instance.GS.DeathLinkOverride == DeathLinkOverride.OverrideOn)
{
    ItemChangerMod.Modules.Add<DeathLinkModule>();
}
```